### PR TITLE
Play any url sound

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: countdown
 Title: A Countdown Timer for R Markdown HTML Presentations and
     Documents
-Version: 0.3.4
+Version: 0.3.5
 Authors@R: 
     person(given = "Garrick",
            family = "Aden-Buie",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# countdown 0.3.5
+
+* Any sound file hosted online can no be played in place of the default sound
+  by setting `play_sound` to the absolute or relative URL of the sound file.
+  
+* The default CSS styles were updated for better automatic vertical centering
+  of the countdown digits.
+
 # countdown 0.3.3
 
 * Added `.countdown-time` class to `<code>` element of timer. Renamed `.digits`

--- a/R/countdown.R
+++ b/R/countdown.R
@@ -61,6 +61,8 @@
 #'   `style = "position: relative; width: min-content;"`.
 #' @param play_sound Play a sound at the end of the timer? If `TRUE`, plays the
 #'   "stage complete" sound courtesy of \link[beepr:beepr-package]{beepr}.
+#'   Alternatively, `play_sound` can be a relative or absolute URL to a sound
+#'   file, such as an `mp3`, `wav`, `ogg`, or other audio file type.
 #' @param font_size The font size of the time displayed in the timer.
 #' @param margin The margin applied to the timer container, default is
 #'   `"0.5em"`.
@@ -213,7 +215,11 @@ countdown <- function(
     )
   )
 
-  if (play_sound) x$attribs$`data-audio` <- "true"
+  if (isTRUE(play_sound)) {
+    x$attribs$`data-audio` <- "true"
+  } else if (is.character(play_sound) && nzchar(play_sound)) {
+    x$attribs$`data-audio` <- play_sound
+  }
   x$attribs$`data-warnwhen` <- if (warn_when > 0) warn_when else 0L
 
   tmpdir <- tempfile("countdown")

--- a/docs/default-timer/index.html
+++ b/docs/default-timer/index.html
@@ -8,7 +8,7 @@
 
 </head>
 <body>
-<div class="countdown" id="timer_5e1a8b09" style="top:0;left:0;" data-warnwhen="5">
+<div class="countdown" id="timer_5e23b0bc" style="top:0;left:0;" data-warnwhen="5">
   <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">15</span></code>
 </div>
 </body>

--- a/docs/default-timer/lib/countdown/countdown.css
+++ b/docs/default-timer/lib/countdown/countdown.css
@@ -26,7 +26,6 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
 }
 .countdown.running {
   border-color: #3C9A5F;

--- a/docs/default-timer/lib/countdown/countdown.js
+++ b/docs/default-timer/lib/countdown/countdown.js
@@ -100,8 +100,9 @@ var counter_update_all = function() {
       update_timer(counters.timer[i]);
 
       // Play countdown sound if data-audio=true on container div
-      if (counters.timer[i].div.dataset.audio && counters.timer[i].value == 5) {
-        counter_play_sound();
+      let audio = counters.timer[i].div.dataset.audio
+      if (audio && counters.timer[i].value == 5) {
+        counter_play_sound(audio);
       }
     }
   }
@@ -117,18 +118,12 @@ var counter_update_all = function() {
   }
 }
 
-var counter_play_sound = function() {
-  try {
-    var finished_sound = new Audio('libs/countdown/smb_stage_clear.mp3');
-    finished_sound.play();
-  } catch (e) {
-    try {
-      var finished_sound = new Audio('smb_stage_clear.mp3');
-      finished_sound.play();
-    } catch (e) {
-      console.log("Unable to locate sound file smb_stage_clear.mp3.")
-    }
+var counter_play_sound = function(url) {
+  if (typeof url === 'boolean') {
+    url = 'libs/countdown/smb_stage_clear.mp3';
   }
+  sound = new Audio(url);
+  sound.play();
 }
 
 var counter_addEventListener = function() {

--- a/docs/fullscreen/index.html
+++ b/docs/fullscreen/index.html
@@ -8,7 +8,7 @@
 
 </head>
 <body>
-<div class="countdown" id="timer_5e1a8bfd" style="top:0;right:0;bottom:0;left:0;margin:0;padding:0;font-size:30vw;" data-warnwhen="5">
+<div class="countdown" id="timer_5e23ae8d" style="top:0;right:0;bottom:0;left:0;margin:0;padding:0;font-size:30vw;" data-warnwhen="5">
   <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">15</span></code>
 </div>
 </body>

--- a/docs/fullscreen/lib/countdown/countdown.css
+++ b/docs/fullscreen/lib/countdown/countdown.css
@@ -26,7 +26,6 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
 }
 .countdown.running {
   border-color: #3C9A5F;

--- a/docs/fullscreen/lib/countdown/countdown.js
+++ b/docs/fullscreen/lib/countdown/countdown.js
@@ -100,8 +100,9 @@ var counter_update_all = function() {
       update_timer(counters.timer[i]);
 
       // Play countdown sound if data-audio=true on container div
-      if (counters.timer[i].div.dataset.audio && counters.timer[i].value == 5) {
-        counter_play_sound();
+      let audio = counters.timer[i].div.dataset.audio
+      if (audio && counters.timer[i].value == 5) {
+        counter_play_sound(audio);
       }
     }
   }
@@ -117,18 +118,12 @@ var counter_update_all = function() {
   }
 }
 
-var counter_play_sound = function() {
-  try {
-    var finished_sound = new Audio('libs/countdown/smb_stage_clear.mp3');
-    finished_sound.play();
-  } catch (e) {
-    try {
-      var finished_sound = new Audio('smb_stage_clear.mp3');
-      finished_sound.play();
-    } catch (e) {
-      console.log("Unable to locate sound file smb_stage_clear.mp3.")
-    }
+var counter_play_sound = function(url) {
+  if (typeof url === 'boolean') {
+    url = 'libs/countdown/smb_stage_clear.mp3';
   }
+  sound = new Audio(url);
+  sound.play();
 }
 
 var counter_addEventListener = function() {

--- a/docs/index.html
+++ b/docs/index.html
@@ -15,7 +15,7 @@ class: middle, left, title-slide
 # <code style='font-size: 200%'>countdown</code>
 ## ⏲ :: 💭 💬 👩‍💻 :: ⏰
 ### <a href='https://github.com/gadenbuie/countdown' style='color: #d33682;'>github.com/gadenbuie/countdown</a>
-### <span style="color: #b58900;">0.3.4</span><br/><span style="color: #2aa198">2020-01-11</span>
+### <span style="color: #b58900;">0.3.5</span><br/><span style="color: #2aa198">2020-01-18</span>
 
 ---
 
@@ -34,7 +34,7 @@ class: center middle
 
 &lt;p style="margin: 11em 0;"&gt;&lt;/p&gt;
 
-<div class="countdown" id="timer_5e1a8c0a" style="top:26%;right:33%;" data-audio="true" data-warnwhen="0">
+<div class="countdown" id="timer_5e23b206" style="top:26%;right:33%;" data-audio="true" data-warnwhen="0">
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">42</span></code>
 </div>
 
@@ -234,7 +234,7 @@ Use the `top`, `bottom`, `left` and `right` arguments to position the timers.
 countdown(minutes = 0, seconds = 7, bottom = 0)
 ```
 
-<div class="countdown" id="timer_5e1a8a95" style="right:0;bottom:0;" data-warnwhen="0">
+<div class="countdown" id="timer_5e23b027" style="right:0;bottom:0;" data-warnwhen="0">
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">07</span></code>
 </div>
 
@@ -244,7 +244,7 @@ countdown(minutes = 0, seconds = 7, bottom = 0)
 countdown(minutes = 0, seconds = 13, top = 0)
 ```
 
-<div class="countdown" id="timer_5e1a8ad7" style="top:0;right:0;" data-warnwhen="0">
+<div class="countdown" id="timer_5e23af0b" style="top:0;right:0;" data-warnwhen="0">
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">13</span></code>
 </div>
 
@@ -254,7 +254,7 @@ countdown(minutes = 0, seconds = 13, top = 0)
 countdown::countdown(minutes = 0, seconds = 21, left = 0)
 ```
 
-<div class="countdown" id="timer_5e1a8a66" style="bottom:0;left:0;" data-warnwhen="0">
+<div class="countdown" id="timer_5e23b0e7" style="bottom:0;left:0;" data-warnwhen="0">
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">21</span></code>
 </div>
 
@@ -280,7 +280,7 @@ countdown(minutes = 1, seconds = 30,
           font_size = "6em")
 ```
 
-<div class="countdown" id="timer_5e1a8bac" style="right:0;bottom:0;left:0;margin:5%;padding:50px;font-size:6em;" data-warnwhen="0">
+<div class="countdown" id="timer_5e23b0d0" style="right:0;bottom:0;left:0;margin:5%;padding:50px;font-size:6em;" data-warnwhen="0">
 <code class="countdown-time"><span class="countdown-digits minutes">01</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">30</span></code>
 </div>
 
@@ -311,7 +311,7 @@ countdown(minutes = 0, seconds = 90,
 
 --
 
-<div class="countdown" id="timer_5e1a8a9a" style="top:0;right:0;bottom:0;left:0;margin:5%;font-size:8em;" data-warnwhen="0">
+<div class="countdown" id="timer_5e23afa2" style="top:0;right:0;bottom:0;left:0;margin:5%;font-size:8em;" data-warnwhen="0">
 <code class="countdown-time"><span class="countdown-digits minutes">01</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">30</span></code>
 </div>
 
@@ -333,7 +333,7 @@ Avoid countdown panic with a timer&lt;br&gt;that only **update**s once **every**
 countdown(minutes = 1, update_every = 15, right = "33%")
 ```
 
-<div class="countdown blink-colon noupdate-15" id="timer_5e1a8cd4" style="right:33%;bottom:0;" data-warnwhen="0">
+<div class="countdown blink-colon noupdate-15" id="timer_5e23b235" style="right:33%;bottom:0;" data-warnwhen="0">
 <code class="countdown-time"><span class="countdown-digits minutes">01</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">00</span></code>
 </div>
 
@@ -348,7 +348,7 @@ Warn your audience that time is about to run out. The warning style is applied t
 countdown(0, 10, warn_when = 5, right = "33%", bottom = "33%")
 ```
 
-<div class="countdown" id="timer_5e1a8b2a" style="right:33%;bottom:33%;" data-warnwhen="5">
+<div class="countdown" id="timer_5e23ae9b" style="right:33%;bottom:33%;" data-warnwhen="5">
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">10</span></code>
 </div>
 
@@ -366,7 +366,7 @@ a very small amount of HTML and CSS and bit more of Javascript.
 Each countdown timer element looks something like this:
 
 ````html
-&lt;div class="countdown" id="timer_5e1a89af" style="right:0;bottom:0;" data-warnwhen="0"&gt;
+&lt;div class="countdown" id="timer_5e23b145" style="right:0;bottom:0;" data-warnwhen="0"&gt;
   &lt;code class="countdown-time"&gt;
     &lt;span class="countdown-digits minutes"&gt;03&lt;/span&gt;
     &lt;span class="countdown-digits colon"&gt;:&lt;/span&gt;
@@ -451,7 +451,7 @@ Set `play_sound = TRUE` to be alerted to the end of the timer with fanfare!
 countdown(0, 10, play_sound = TRUE)
 ```
 
-<div class="countdown" id="timer_5e1a8a57" style="right:0;bottom:0;" data-audio="true" data-warnwhen="0">
+<div class="countdown" id="timer_5e23af8c" style="right:0;bottom:0;" data-audio="true" data-warnwhen="0">
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">10</span></code>
 </div>
 

--- a/docs/libs/countdown/countdown.css
+++ b/docs/libs/countdown/countdown.css
@@ -26,7 +26,6 @@
 }
 .countdown-digits {
   color: #d33682;
-  vertical-align: text-bottom;
 }
 .countdown.running {
   border-color: #259088;

--- a/docs/libs/countdown/countdown.js
+++ b/docs/libs/countdown/countdown.js
@@ -100,8 +100,9 @@ var counter_update_all = function() {
       update_timer(counters.timer[i]);
 
       // Play countdown sound if data-audio=true on container div
-      if (counters.timer[i].div.dataset.audio && counters.timer[i].value == 5) {
-        counter_play_sound();
+      let audio = counters.timer[i].div.dataset.audio
+      if (audio && counters.timer[i].value == 5) {
+        counter_play_sound(audio);
       }
     }
   }
@@ -117,18 +118,12 @@ var counter_update_all = function() {
   }
 }
 
-var counter_play_sound = function() {
-  try {
-    var finished_sound = new Audio('libs/countdown/smb_stage_clear.mp3');
-    finished_sound.play();
-  } catch (e) {
-    try {
-      var finished_sound = new Audio('smb_stage_clear.mp3');
-      finished_sound.play();
-    } catch (e) {
-      console.log("Unable to locate sound file smb_stage_clear.mp3.")
-    }
+var counter_play_sound = function(url) {
+  if (typeof url === 'boolean') {
+    url = 'libs/countdown/smb_stage_clear.mp3';
   }
+  sound = new Audio(url);
+  sound.play();
 }
 
 var counter_addEventListener = function() {

--- a/inst/countdown.css
+++ b/inst/countdown.css
@@ -26,7 +26,6 @@
 }
 .countdown-digits {
   color: {{color_text}};
-  vertical-align: text-bottom;
 }
 .countdown.running {
   border-color: {{color_running_border}};

--- a/inst/countdown.js
+++ b/inst/countdown.js
@@ -100,8 +100,9 @@ var counter_update_all = function() {
       update_timer(counters.timer[i]);
 
       // Play countdown sound if data-audio=true on container div
-      if (counters.timer[i].div.dataset.audio && counters.timer[i].value == 5) {
-        counter_play_sound();
+      let audio = counters.timer[i].div.dataset.audio
+      if (audio && counters.timer[i].value == 5) {
+        counter_play_sound(audio);
       }
     }
   }
@@ -117,18 +118,12 @@ var counter_update_all = function() {
   }
 }
 
-var counter_play_sound = function() {
-  try {
-    var finished_sound = new Audio('libs/countdown/smb_stage_clear.mp3');
-    finished_sound.play();
-  } catch (e) {
-    try {
-      var finished_sound = new Audio('smb_stage_clear.mp3');
-      finished_sound.play();
-    } catch (e) {
-      console.log("Unable to locate sound file smb_stage_clear.mp3.")
-    }
+var counter_play_sound = function(url) {
+  if (typeof url === 'boolean') {
+    url = 'libs/countdown/smb_stage_clear.mp3';
   }
+  sound = new Audio(url);
+  sound.play();
 }
 
 var counter_addEventListener = function() {

--- a/man/countdown.Rd
+++ b/man/countdown.Rd
@@ -83,7 +83,9 @@ absolutely, as in the default), set
 \code{style = "position: relative; width: min-content;"}.}
 
 \item{play_sound}{Play a sound at the end of the timer? If \code{TRUE}, plays the
-"stage complete" sound courtesy of \link[beepr:beepr-package]{beepr}.}
+"stage complete" sound courtesy of \link[beepr:beepr-package]{beepr}.
+Alternatively, \code{play_sound} can be a relative or absolute URL to a sound
+file, such as an \code{mp3}, \code{wav}, \code{ogg}, or other audio file type.}
 
 \item{font_size}{The font size of the time displayed in the timer.}
 

--- a/tests/testthat/css_template/countdown_default.css
+++ b/tests/testthat/css_template/countdown_default.css
@@ -26,7 +26,7 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
+  vertical-align: unset;
 }
 .countdown.running {
   border-color: #3C9A5F;

--- a/tests/testthat/css_template/countdown_finished-colors.css
+++ b/tests/testthat/css_template/countdown_finished-colors.css
@@ -26,7 +26,7 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
+  vertical-align: unset;
 }
 .countdown.running {
   border-color: #3C9A5F;

--- a/tests/testthat/css_template/countdown_font-and-border.css
+++ b/tests/testthat/css_template/countdown_font-and-border.css
@@ -26,7 +26,7 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
+  vertical-align: unset;
 }
 .countdown.running {
   border-color: #3C9A5F;

--- a/tests/testthat/css_template/countdown_fullscreen.css
+++ b/tests/testthat/css_template/countdown_fullscreen.css
@@ -26,7 +26,7 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
+  vertical-align: unset;
 }
 .countdown.running {
   border-color: #3C9A5F;

--- a/tests/testthat/css_template/countdown_margin-padding.css
+++ b/tests/testthat/css_template/countdown_margin-padding.css
@@ -26,7 +26,7 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
+  vertical-align: unset;
 }
 .countdown.running {
   border-color: #3C9A5F;

--- a/tests/testthat/css_template/countdown_no-shadow.css
+++ b/tests/testthat/css_template/countdown_no-shadow.css
@@ -24,7 +24,7 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
+  vertical-align: unset;
 }
 .countdown.running {
   border-color: #3C9A5F;

--- a/tests/testthat/css_template/countdown_running-colors.css
+++ b/tests/testthat/css_template/countdown_running-colors.css
@@ -26,7 +26,7 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
+  vertical-align: unset;
 }
 .countdown.running {
   border-color: #B82222;

--- a/tests/testthat/css_template/countdown_top-left.css
+++ b/tests/testthat/css_template/countdown_top-left.css
@@ -26,7 +26,7 @@
 }
 .countdown-digits {
   color: inherit;
-  vertical-align: text-bottom;
+  vertical-align: unset;
 }
 .countdown.running {
   border-color: #3C9A5F;


### PR DESCRIPTION
Set `play_sound = "path/to/sound.mp3"` or `play_sound = "https://best-sounds.com/fun.wav"` (not real examples) to play any desired sound instead of the built-in sound.

This can also be used if you use a non-standard `lib_dir` in xaringan:

```yaml
output:
  xaringan::moon_reader:
    lib_dir: "assets/libs"
```

```r
countdown::countdown(play_sound = "assets/libs/countdown/smb_stage_clear.mp3")
```