### PR TITLE
Emit native browser events in addition to Shiny communication

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,4 +22,4 @@ Suggests:
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,8 +13,16 @@
   makes it easier to customize and use countdown in other projects and
   settings. (#36)
 
+* Implemented emitting of native browser events alongside Shiny communication. (#37)
+
+* Added two new event types: `"finished"` when the timer completes its cycle and `"warning"` when it reaches the warning period. (#37)
+  
 * Set `class = "inline"` in `countdown()` to create an inline, rather than
   absolute-positioned, countdown timer. (#36)
+  
+## Changes
+
+* Switched to using `{bslib}` to stylize the demo countdown shiny app. (#37)
 
 # countdown 0.4.0
 

--- a/docs/default-timer/index.html
+++ b/docs/default-timer/index.html
@@ -8,7 +8,7 @@
 
 </head>
 <body>
-<div class="countdown" id="timer_e46e8783" data-warn-when="5" data-update-every="1" tabindex="0" style="top:0;right:0;left:0;">
+<div class="countdown" id="timer_51a6f8cb" data-warn-when="5" data-update-every="1" tabindex="0" style="top:0;right:0;left:0;">
   <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
   <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">15</span></code>
 </div>

--- a/docs/default-timer/lib/countdown/countdown.css
+++ b/docs/default-timer/lib/countdown/countdown.css
@@ -1,8 +1,8 @@
 .countdown {
-  --_running-color: var(--countdown-color-running-text);
+  --_running-color: var(--countdown-color-running-text, rgba(0, 0, 0, 0.8));
   --_running-background: var(--countdown-color-running-background, #43AC6A);
   --_running-border-color: var(--countdown-color-running-border, rgba(0, 0, 0, 0.1));
-  --_finished-color: var(--countdown-color-finished-text);
+  --_finished-color: var(--countdown-color-finished-text, rgba(0, 0, 0, 0.7));
   --_finished-background: var(--countdown-color-finished-background, #F04124);
   --_finished-border-color: var(--countdown-color-finished-border, rgba(0, 0, 0, 0.1));
 
@@ -11,7 +11,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  background: var(--countdown-color-background);
+  background: var(--countdown-color-background, inherit);
   font-size: var(--countdown-font-size, 3rem);
   line-height: var(--countdown-line-height, 1);
   border-color: var(--countdown-color-border, #ddd);
@@ -39,6 +39,7 @@
   background: none;
   font-size: 100%;
   padding: 0;
+  color: currentColor;
 }
 
 .countdown-digits {
@@ -69,7 +70,7 @@
 }
 
 .countdown.running.warning .countdown-digits {
-  color: var(--countdown-color-warning-text);
+  color: var(--countdown-color-warning-text, rgba(0, 0, 0, 0.7));
 }
 
 .countdown.running.blink-colon .countdown-digits.colon {
@@ -93,10 +94,10 @@
 }
 
 .countdown-controls>button {
+  position: relative;
   font-size: 1.5rem;
   width: 1rem;
   height: 1rem;
-  display: inline-block;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -115,6 +116,15 @@
   transform: translate(0, var(--_button-bump));
 }
 
+/* increase hit area of the +/- buttons */
+.countdown .countdown-controls > button::after {
+	content: "";
+	height: 200%;
+	width: 200%;
+	position: absolute;
+	border-radius: 50%;
+}
+
 .countdown .countdown-controls>button:last-child {
   color: var(--_running-color);
   background-color: var(--_running-background);
@@ -127,7 +137,7 @@
   border-color: var(--_finished-border-color);
 }
 
-.countdown.running:hover, countdown.running:focus-within {
+.countdown.running:hover, .countdown.running:focus-within {
   --_opacity: 1;
 }
 

--- a/docs/default-timer/lib/countdown/countdown.js
+++ b/docs/default-timer/lib/countdown/countdown.js
@@ -76,7 +76,7 @@ class CountdownTimer {
           window.Reveal.on('slidechanged', revealStartTimer)
         }
       } else if (window.IntersectionObserver) {
-        // All other situtations use IntersectionObserver
+        // All other situations use IntersectionObserver
         const onVisible = (element, callback) => {
           new window.IntersectionObserver((entries, observer) => {
             entries.forEach(entry => {
@@ -108,7 +108,7 @@ class CountdownTimer {
     ;['click', 'touchend'].forEach(function (eventType) {
       self.element.addEventListener(eventType, function (ev) {
         haltEvent(ev)
-        self.is_running ? self.stop() : self.start()
+        self.is_running ? self.stop({manual: true}) : self.start()
       })
     })
     this.element.addEventListener('keydown', function (ev) {
@@ -119,7 +119,7 @@ class CountdownTimer {
       if (!isSpaceOrEnter(ev) && !isArrowUpOrDown(ev)) return
       haltEvent(ev)
       if (isSpaceOrEnter(ev)) {
-        self.is_running ? self.stop() : self.start()
+        self.is_running ? self.stop({manual: true}) : self.start()
         return
       }
 
@@ -196,7 +196,7 @@ class CountdownTimer {
       this.end = Date.now() + this.duration * 1000
     }
 
-    this.reportStateToShiny('start')
+    this.emitStateEvent('start')
 
     this.element.classList.remove('finished')
     this.element.classList.add('running')
@@ -262,14 +262,18 @@ class CountdownTimer {
       Math.round(remaining) % this.update_every === 0
 
     if (should_update) {
-      this.element.classList.toggle('warning', remaining <= this.warn_when)
+      const is_warning = remaining <= this.warn_when
+      if (is_warning && !this.element.classList.contains('warning')) {
+        this.emitStateEvent('warning')
+      }
+      this.element.classList.toggle('warning', is_warning)
       this.display = { minutes, seconds }
       setRemainingTime('.minutes', minutes)
       setRemainingTime('.seconds', seconds)
     }
   }
 
-  stop () {
+  stop ({manual = false} = {}) {
     const { remaining } = this.remainingTime()
     if (remaining > 1) {
       this.remaining = remaining
@@ -280,17 +284,19 @@ class CountdownTimer {
     this.element.classList.add('finished')
     this.is_running = false
     this.end = null
-    this.reportStateToShiny('stop')
+    this.emitStateEvent(manual ? 'stop' : 'finished')
     this.timeout = clearTimeout(this.timeout)
   }
 
   reset () {
-    this.stop()
+    this.stop({manual: true})
     this.remaining = null
     this.update(true)
-    this.reportStateToShiny('reset')
+
     this.element.classList.remove('finished')
     this.element.classList.remove('warning')
+    this.emitEvents = true
+    this.emitStateEvent('reset')
   }
 
   setValues (opts) {
@@ -316,7 +322,7 @@ class CountdownTimer {
         this.start()
       }
     }
-    this.reportStateToShiny('update')
+    this.emitStateEvent('update')
     this.update(true)
   }
 
@@ -333,7 +339,7 @@ class CountdownTimer {
       newRemaining = Math.round(newRemaining / 5) * 5
     }
     this.setRemaining(newRemaining)
-    this.reportStateToShiny(val > 0 ? 'bumpUp' : 'bumpDown')
+    this.emitStateEvent(val > 0 ? 'bumpUp' : 'bumpDown')
     this.update(true)
   }
 
@@ -394,15 +400,10 @@ class CountdownTimer {
     }
   }
 
-  reportStateToShiny (action) {
-    if (!window.Shiny) return
-
-    const inputId = this.element.id
+  emitStateEvent (action) {
     const data = {
-      event: {
-        action,
-        time: new Date().toISOString()
-      },
+      action,
+      time: new Date().toISOString(),
       timer: {
         is_running: this.is_running,
         end: this.end ? new Date(this.end).toISOString() : null,
@@ -410,15 +411,24 @@ class CountdownTimer {
       }
     }
 
-    function shinySetInputValue () {
-      if (!window.Shiny.setInputValue) {
-        setTimeout(shinySetInputValue, 100)
-        return
-      }
-      window.Shiny.setInputValue(inputId, data)
+    this.reportStateToShiny(data)
+    this.element.dispatchEvent(new CustomEvent('countdown', { detail: data, bubbles: true }))
+  }
+
+  reportStateToShiny (data) {
+    if (!window.Shiny) return
+
+    if (!window.Shiny.setInputValue) {
+      // We're in Shiny but it isn't ready for input updates yet
+      setTimeout(() => this.reportStateToShiny(data), 100)
+      return
     }
 
-    shinySetInputValue()
+    const { action, time, timer } = data
+
+    const shinyData = { event: { action, time }, timer }
+
+    window.Shiny.setInputValue(this.element.id, shinyData)
   }
 }
 
@@ -453,7 +463,7 @@ class CountdownTimer {
       Shiny.addCustomMessageHandler('countdown:stop', function (id) {
         const el = document.getElementById(id)
         if (!el) return
-        el.countdown.stop()
+        el.countdown.stop({manual: true})
       })
 
       Shiny.addCustomMessageHandler('countdown:reset', function (id) {

--- a/docs/fullscreen/index.html
+++ b/docs/fullscreen/index.html
@@ -8,7 +8,7 @@
 
 </head>
 <body>
-<div class="countdown countdown-fullscreen" id="timer_485ece55" data-warn-when="5" data-update-every="1" tabindex="0" style="top:0;right:0;bottom:0;left:0;--countdown-margin:0;--countdown-padding:0;--countdown-font-size:30vw;--countdown-border-width:0;--countdown-border-radius:0;">
+<div class="countdown countdown-fullscreen" id="timer_af151310" data-warn-when="5" data-update-every="1" tabindex="0" style="top:0;right:0;bottom:0;left:0;--countdown-margin:0;--countdown-padding:0;--countdown-font-size:30vw;--countdown-border-width:0;--countdown-border-radius:0;">
   <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
   <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">15</span></code>
 </div>

--- a/docs/fullscreen/lib/countdown/countdown.css
+++ b/docs/fullscreen/lib/countdown/countdown.css
@@ -1,8 +1,8 @@
 .countdown {
-  --_running-color: var(--countdown-color-running-text);
+  --_running-color: var(--countdown-color-running-text, rgba(0, 0, 0, 0.8));
   --_running-background: var(--countdown-color-running-background, #43AC6A);
   --_running-border-color: var(--countdown-color-running-border, rgba(0, 0, 0, 0.1));
-  --_finished-color: var(--countdown-color-finished-text);
+  --_finished-color: var(--countdown-color-finished-text, rgba(0, 0, 0, 0.7));
   --_finished-background: var(--countdown-color-finished-background, #F04124);
   --_finished-border-color: var(--countdown-color-finished-border, rgba(0, 0, 0, 0.1));
 
@@ -11,7 +11,7 @@
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  background: var(--countdown-color-background);
+  background: var(--countdown-color-background, inherit);
   font-size: var(--countdown-font-size, 3rem);
   line-height: var(--countdown-line-height, 1);
   border-color: var(--countdown-color-border, #ddd);
@@ -39,6 +39,7 @@
   background: none;
   font-size: 100%;
   padding: 0;
+  color: currentColor;
 }
 
 .countdown-digits {
@@ -69,7 +70,7 @@
 }
 
 .countdown.running.warning .countdown-digits {
-  color: var(--countdown-color-warning-text);
+  color: var(--countdown-color-warning-text, rgba(0, 0, 0, 0.7));
 }
 
 .countdown.running.blink-colon .countdown-digits.colon {
@@ -93,10 +94,10 @@
 }
 
 .countdown-controls>button {
+  position: relative;
   font-size: 1.5rem;
   width: 1rem;
   height: 1rem;
-  display: inline-block;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -115,6 +116,15 @@
   transform: translate(0, var(--_button-bump));
 }
 
+/* increase hit area of the +/- buttons */
+.countdown .countdown-controls > button::after {
+	content: "";
+	height: 200%;
+	width: 200%;
+	position: absolute;
+	border-radius: 50%;
+}
+
 .countdown .countdown-controls>button:last-child {
   color: var(--_running-color);
   background-color: var(--_running-background);
@@ -127,7 +137,7 @@
   border-color: var(--_finished-border-color);
 }
 
-.countdown.running:hover, countdown.running:focus-within {
+.countdown.running:hover, .countdown.running:focus-within {
   --_opacity: 1;
 }
 

--- a/docs/fullscreen/lib/countdown/countdown.js
+++ b/docs/fullscreen/lib/countdown/countdown.js
@@ -76,7 +76,7 @@ class CountdownTimer {
           window.Reveal.on('slidechanged', revealStartTimer)
         }
       } else if (window.IntersectionObserver) {
-        // All other situtations use IntersectionObserver
+        // All other situations use IntersectionObserver
         const onVisible = (element, callback) => {
           new window.IntersectionObserver((entries, observer) => {
             entries.forEach(entry => {
@@ -108,7 +108,7 @@ class CountdownTimer {
     ;['click', 'touchend'].forEach(function (eventType) {
       self.element.addEventListener(eventType, function (ev) {
         haltEvent(ev)
-        self.is_running ? self.stop() : self.start()
+        self.is_running ? self.stop({manual: true}) : self.start()
       })
     })
     this.element.addEventListener('keydown', function (ev) {
@@ -119,7 +119,7 @@ class CountdownTimer {
       if (!isSpaceOrEnter(ev) && !isArrowUpOrDown(ev)) return
       haltEvent(ev)
       if (isSpaceOrEnter(ev)) {
-        self.is_running ? self.stop() : self.start()
+        self.is_running ? self.stop({manual: true}) : self.start()
         return
       }
 
@@ -196,7 +196,7 @@ class CountdownTimer {
       this.end = Date.now() + this.duration * 1000
     }
 
-    this.reportStateToShiny('start')
+    this.emitStateEvent('start')
 
     this.element.classList.remove('finished')
     this.element.classList.add('running')
@@ -262,14 +262,18 @@ class CountdownTimer {
       Math.round(remaining) % this.update_every === 0
 
     if (should_update) {
-      this.element.classList.toggle('warning', remaining <= this.warn_when)
+      const is_warning = remaining <= this.warn_when
+      if (is_warning && !this.element.classList.contains('warning')) {
+        this.emitStateEvent('warning')
+      }
+      this.element.classList.toggle('warning', is_warning)
       this.display = { minutes, seconds }
       setRemainingTime('.minutes', minutes)
       setRemainingTime('.seconds', seconds)
     }
   }
 
-  stop () {
+  stop ({manual = false} = {}) {
     const { remaining } = this.remainingTime()
     if (remaining > 1) {
       this.remaining = remaining
@@ -280,17 +284,19 @@ class CountdownTimer {
     this.element.classList.add('finished')
     this.is_running = false
     this.end = null
-    this.reportStateToShiny('stop')
+    this.emitStateEvent(manual ? 'stop' : 'finished')
     this.timeout = clearTimeout(this.timeout)
   }
 
   reset () {
-    this.stop()
+    this.stop({manual: true})
     this.remaining = null
     this.update(true)
-    this.reportStateToShiny('reset')
+
     this.element.classList.remove('finished')
     this.element.classList.remove('warning')
+    this.emitEvents = true
+    this.emitStateEvent('reset')
   }
 
   setValues (opts) {
@@ -316,7 +322,7 @@ class CountdownTimer {
         this.start()
       }
     }
-    this.reportStateToShiny('update')
+    this.emitStateEvent('update')
     this.update(true)
   }
 
@@ -333,7 +339,7 @@ class CountdownTimer {
       newRemaining = Math.round(newRemaining / 5) * 5
     }
     this.setRemaining(newRemaining)
-    this.reportStateToShiny(val > 0 ? 'bumpUp' : 'bumpDown')
+    this.emitStateEvent(val > 0 ? 'bumpUp' : 'bumpDown')
     this.update(true)
   }
 
@@ -394,15 +400,10 @@ class CountdownTimer {
     }
   }
 
-  reportStateToShiny (action) {
-    if (!window.Shiny) return
-
-    const inputId = this.element.id
+  emitStateEvent (action) {
     const data = {
-      event: {
-        action,
-        time: new Date().toISOString()
-      },
+      action,
+      time: new Date().toISOString(),
       timer: {
         is_running: this.is_running,
         end: this.end ? new Date(this.end).toISOString() : null,
@@ -410,15 +411,24 @@ class CountdownTimer {
       }
     }
 
-    function shinySetInputValue () {
-      if (!window.Shiny.setInputValue) {
-        setTimeout(shinySetInputValue, 100)
-        return
-      }
-      window.Shiny.setInputValue(inputId, data)
+    this.reportStateToShiny(data)
+    this.element.dispatchEvent(new CustomEvent('countdown', { detail: data, bubbles: true }))
+  }
+
+  reportStateToShiny (data) {
+    if (!window.Shiny) return
+
+    if (!window.Shiny.setInputValue) {
+      // We're in Shiny but it isn't ready for input updates yet
+      setTimeout(() => this.reportStateToShiny(data), 100)
+      return
     }
 
-    shinySetInputValue()
+    const { action, time, timer } = data
+
+    const shinyData = { event: { action, time }, timer }
+
+    window.Shiny.setInputValue(this.element.id, shinyData)
   }
 }
 
@@ -453,7 +463,7 @@ class CountdownTimer {
       Shiny.addCustomMessageHandler('countdown:stop', function (id) {
         const el = document.getElementById(id)
         if (!el) return
-        el.countdown.stop()
+        el.countdown.stop({manual: true})
       })
 
       Shiny.addCustomMessageHandler('countdown:reset', function (id) {

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,8 +6,6 @@
     <meta name="author" content="Garrick Aden-Buie" />
     <meta name="date" content="2024-01-20" />
     <script src="libs/header-attrs/header-attrs.js"></script>
-    <link href="libs/tile-view/tile-view.css" rel="stylesheet" />
-    <script src="libs/tile-view/tile-view.js"></script>
     <link href="libs/countdown/countdown.css" rel="stylesheet" />
     <script src="libs/countdown/countdown.js"></script>
     <link rel="stylesheet" href="xaringan-themer.css" type="text/css" />
@@ -51,7 +49,7 @@ class: center middle
 
 &lt;p style="margin: 11em 0;"&gt;&lt;/p&gt;
 
-<div class="countdown" id="timer_4b9285f4" data-update-every="1" data-play-sound="true" tabindex="0" style="top:26%;right:33%;">
+<div class="countdown" id="timer_e82bbbb8" data-update-every="1" data-play-sound="true" tabindex="0" style="top:26%;right:33%;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">42</span></code>
 </div><style>:root {--countdown-font-size:3rem;--countdown-margin:0.6em;--countdown-padding:10px 15px;--countdown-box-shadow:0px 4px 10px 0px rgba(50, 50, 50, 0.4);--countdown-border-width:0.1875 rem;--countdown-border-radius:0.9rem;--countdown-line-height:1;--countdown-color-border:#d33682;--countdown-color-background:inherit;--countdown-color-text:#d33682;--countdown-color-running-background:#2aa198;--countdown-color-running-border:#0D9188FF;--countdown-color-running-text:#073642;--countdown-color-finished-background:#dc322f;--countdown-color-finished-border:#CD1F1BFF;--countdown-color-finished-text:#fdf6e3;--countdown-color-warning-background:#E6C229;--countdown-color-warning-border:#CEAC04FF;--countdown-color-warning-text:#3A2F02FF;}</style>
@@ -253,7 +251,7 @@ Use the `top`, `bottom`, `left` and `right` arguments to position the timers.
 countdown(minutes = 0, seconds = 7, bottom = 0)
 ```
 
-<div class="countdown" id="timer_06f0aba5" data-update-every="1" tabindex="0" style="right:0;bottom:0;">
+<div class="countdown" id="timer_2cf1e95b" data-update-every="1" tabindex="0" style="right:0;bottom:0;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">07</span></code>
 </div>
@@ -264,7 +262,7 @@ countdown(minutes = 0, seconds = 7, bottom = 0)
 countdown(minutes = 0, seconds = 13, top = 0)
 ```
 
-<div class="countdown" id="timer_7e19137e" data-update-every="1" tabindex="0" style="top:0;right:0;">
+<div class="countdown" id="timer_90a07888" data-update-every="1" tabindex="0" style="top:0;right:0;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">13</span></code>
 </div>
@@ -275,7 +273,7 @@ countdown(minutes = 0, seconds = 13, top = 0)
 countdown::countdown(minutes = 0, seconds = 21, left = 0)
 ```
 
-<div class="countdown" id="timer_bbae9bb3" data-update-every="1" tabindex="0" style="bottom:0;left:0;">
+<div class="countdown" id="timer_9305c227" data-update-every="1" tabindex="0" style="bottom:0;left:0;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">21</span></code>
 </div>
@@ -294,7 +292,7 @@ countdown::countdown(minutes = 0, seconds = 21, left = 0)
 countdown(start_immediately = TRUE)
 ```
 
-<div class="countdown" id="timer_d8a083e3" data-update-every="1" data-start-immediately="true" tabindex="0" style="right:0;bottom:0;">
+<div class="countdown" id="timer_a6fc9ed5" data-update-every="1" data-start-immediately="true" tabindex="0" style="right:0;bottom:0;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">01</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">00</span></code>
 </div>
@@ -322,7 +320,7 @@ countdown(minutes = 1, seconds = 30,
           font_size = "6em")
 ```
 
-<div class="countdown" id="timer_ceb11b71" data-update-every="1" tabindex="0" style="right:0;bottom:0;left:0;--countdown-margin:5%;--countdown-padding:50px;--countdown-font-size:6em;">
+<div class="countdown" id="timer_55781858" data-update-every="1" tabindex="0" style="right:0;bottom:0;left:0;--countdown-margin:5%;--countdown-padding:50px;--countdown-font-size:6em;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">01</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">30</span></code>
 </div>
@@ -354,7 +352,7 @@ countdown(minutes = 0, seconds = 90,
 
 --
 
-<div class="countdown" id="timer_b5030fde" data-update-every="1" tabindex="0" style="top:0;right:0;bottom:0;left:0;--countdown-margin:5%;--countdown-font-size:8em;">
+<div class="countdown" id="timer_ad95bed9" data-update-every="1" tabindex="0" style="top:0;right:0;bottom:0;left:0;--countdown-margin:5%;--countdown-font-size:8em;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">01</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">30</span></code>
 </div>
@@ -377,7 +375,7 @@ Avoid countdown panic with a timer&lt;br&gt;that only **update**s once **every**
 countdown(minutes = 1, update_every = 15, right = "33%")
 ```
 
-<div class="countdown" id="timer_84df405b" data-update-every="15" data-blink-colon="true" tabindex="0" style="right:33%;bottom:0;">
+<div class="countdown" id="timer_b5267b78" data-update-every="15" data-blink-colon="true" tabindex="0" style="right:33%;bottom:0;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">01</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">00</span></code>
 </div>
@@ -393,7 +391,7 @@ Warn your audience that time is about to run out. The warning style is applied t
 countdown(0, 10, warn_when = 5, right = "33%", bottom = "33%", blink_colon = TRUE)
 ```
 
-<div class="countdown" id="timer_a4283db5" data-warn-when="5" data-update-every="1" data-blink-colon="true" tabindex="0" style="right:33%;bottom:33%;">
+<div class="countdown" id="timer_621ab03e" data-warn-when="5" data-update-every="1" data-blink-colon="true" tabindex="0" style="right:33%;bottom:33%;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">10</span></code>
 </div>
@@ -412,7 +410,7 @@ a very small amount of HTML and CSS and bit more of Javascript.
 Each countdown timer element looks something like this:
 
 ````html
-&lt;div class="countdown" id="timer_5a7dc43b" data-update-every="1" tabindex="0" style="right:0;bottom:0;"&gt;
+&lt;div class="countdown" id="timer_f9a5fa61" data-update-every="1" tabindex="0" style="right:0;bottom:0;"&gt;
   &lt;div class="countdown-controls"&gt;&lt;button class="countdown-bump-down"&gt;&amp;minus;&lt;/button&gt;&lt;button class="countdown-bump-up"&gt;&amp;plus;&lt;/button&gt;&lt;/div&gt;
   &lt;code class="countdown-time"&gt;
     &lt;span class="countdown-digits minutes"&gt;03&lt;/span&gt;
@@ -499,7 +497,7 @@ Set `play_sound = TRUE` to be alerted to the end of the timer with fanfare!
 countdown(0, 10, play_sound = TRUE)
 ```
 
-<div class="countdown" id="timer_6985c935" data-update-every="1" data-play-sound="true" tabindex="0" style="right:0;bottom:0;">
+<div class="countdown" id="timer_ca7e0457" data-update-every="1" data-play-sound="true" tabindex="0" style="right:0;bottom:0;">
 <div class="countdown-controls"><button class="countdown-bump-down">&minus;</button><button class="countdown-bump-up">&plus;</button></div>
 <code class="countdown-time"><span class="countdown-digits minutes">00</span><span class="countdown-digits colon">:</span><span class="countdown-digits seconds">10</span></code>
 </div>

--- a/docs/libs/countdown/countdown.js
+++ b/docs/libs/countdown/countdown.js
@@ -76,7 +76,7 @@ class CountdownTimer {
           window.Reveal.on('slidechanged', revealStartTimer)
         }
       } else if (window.IntersectionObserver) {
-        // All other situtations use IntersectionObserver
+        // All other situations use IntersectionObserver
         const onVisible = (element, callback) => {
           new window.IntersectionObserver((entries, observer) => {
             entries.forEach(entry => {
@@ -108,7 +108,7 @@ class CountdownTimer {
     ;['click', 'touchend'].forEach(function (eventType) {
       self.element.addEventListener(eventType, function (ev) {
         haltEvent(ev)
-        self.is_running ? self.stop() : self.start()
+        self.is_running ? self.stop({manual: true}) : self.start()
       })
     })
     this.element.addEventListener('keydown', function (ev) {
@@ -119,7 +119,7 @@ class CountdownTimer {
       if (!isSpaceOrEnter(ev) && !isArrowUpOrDown(ev)) return
       haltEvent(ev)
       if (isSpaceOrEnter(ev)) {
-        self.is_running ? self.stop() : self.start()
+        self.is_running ? self.stop({manual: true}) : self.start()
         return
       }
 
@@ -196,7 +196,7 @@ class CountdownTimer {
       this.end = Date.now() + this.duration * 1000
     }
 
-    this.reportStateToShiny('start')
+    this.emitStateEvent('start')
 
     this.element.classList.remove('finished')
     this.element.classList.add('running')
@@ -262,14 +262,18 @@ class CountdownTimer {
       Math.round(remaining) % this.update_every === 0
 
     if (should_update) {
-      this.element.classList.toggle('warning', remaining <= this.warn_when)
+      const is_warning = remaining <= this.warn_when
+      if (is_warning && !this.element.classList.contains('warning')) {
+        this.emitStateEvent('warning')
+      }
+      this.element.classList.toggle('warning', is_warning)
       this.display = { minutes, seconds }
       setRemainingTime('.minutes', minutes)
       setRemainingTime('.seconds', seconds)
     }
   }
 
-  stop () {
+  stop ({manual = false} = {}) {
     const { remaining } = this.remainingTime()
     if (remaining > 1) {
       this.remaining = remaining
@@ -280,17 +284,19 @@ class CountdownTimer {
     this.element.classList.add('finished')
     this.is_running = false
     this.end = null
-    this.reportStateToShiny('stop')
+    this.emitStateEvent(manual ? 'stop' : 'finished')
     this.timeout = clearTimeout(this.timeout)
   }
 
   reset () {
-    this.stop()
+    this.stop({manual: true})
     this.remaining = null
     this.update(true)
-    this.reportStateToShiny('reset')
+
     this.element.classList.remove('finished')
     this.element.classList.remove('warning')
+    this.emitEvents = true
+    this.emitStateEvent('reset')
   }
 
   setValues (opts) {
@@ -316,7 +322,7 @@ class CountdownTimer {
         this.start()
       }
     }
-    this.reportStateToShiny('update')
+    this.emitStateEvent('update')
     this.update(true)
   }
 
@@ -333,7 +339,7 @@ class CountdownTimer {
       newRemaining = Math.round(newRemaining / 5) * 5
     }
     this.setRemaining(newRemaining)
-    this.reportStateToShiny(val > 0 ? 'bumpUp' : 'bumpDown')
+    this.emitStateEvent(val > 0 ? 'bumpUp' : 'bumpDown')
     this.update(true)
   }
 
@@ -394,15 +400,10 @@ class CountdownTimer {
     }
   }
 
-  reportStateToShiny (action) {
-    if (!window.Shiny) return
-
-    const inputId = this.element.id
+  emitStateEvent (action) {
     const data = {
-      event: {
-        action,
-        time: new Date().toISOString()
-      },
+      action,
+      time: new Date().toISOString(),
       timer: {
         is_running: this.is_running,
         end: this.end ? new Date(this.end).toISOString() : null,
@@ -410,15 +411,24 @@ class CountdownTimer {
       }
     }
 
-    function shinySetInputValue () {
-      if (!window.Shiny.setInputValue) {
-        setTimeout(shinySetInputValue, 100)
-        return
-      }
-      window.Shiny.setInputValue(inputId, data)
+    this.reportStateToShiny(data)
+    this.element.dispatchEvent(new CustomEvent('countdown', { detail: data, bubbles: true }))
+  }
+
+  reportStateToShiny (data) {
+    if (!window.Shiny) return
+
+    if (!window.Shiny.setInputValue) {
+      // We're in Shiny but it isn't ready for input updates yet
+      setTimeout(() => this.reportStateToShiny(data), 100)
+      return
     }
 
-    shinySetInputValue()
+    const { action, time, timer } = data
+
+    const shinyData = { event: { action, time }, timer }
+
+    window.Shiny.setInputValue(this.element.id, shinyData)
   }
 }
 
@@ -453,7 +463,7 @@ class CountdownTimer {
       Shiny.addCustomMessageHandler('countdown:stop', function (id) {
         const el = document.getElementById(id)
         if (!el) return
-        el.countdown.stop()
+        el.countdown.stop({manual: true})
       })
 
       Shiny.addCustomMessageHandler('countdown:reset', function (id) {

--- a/inst/countdown/countdown.js
+++ b/inst/countdown/countdown.js
@@ -76,7 +76,7 @@ class CountdownTimer {
           window.Reveal.on('slidechanged', revealStartTimer)
         }
       } else if (window.IntersectionObserver) {
-        // All other situtations use IntersectionObserver
+        // All other situations use IntersectionObserver
         const onVisible = (element, callback) => {
           new window.IntersectionObserver((entries, observer) => {
             entries.forEach(entry => {
@@ -108,7 +108,7 @@ class CountdownTimer {
     ;['click', 'touchend'].forEach(function (eventType) {
       self.element.addEventListener(eventType, function (ev) {
         haltEvent(ev)
-        self.is_running ? self.stop() : self.start()
+        self.is_running ? self.stop({manual: true}) : self.start()
       })
     })
     this.element.addEventListener('keydown', function (ev) {
@@ -119,7 +119,7 @@ class CountdownTimer {
       if (!isSpaceOrEnter(ev) && !isArrowUpOrDown(ev)) return
       haltEvent(ev)
       if (isSpaceOrEnter(ev)) {
-        self.is_running ? self.stop() : self.start()
+        self.is_running ? self.stop({manual: true}) : self.start()
         return
       }
 
@@ -196,7 +196,7 @@ class CountdownTimer {
       this.end = Date.now() + this.duration * 1000
     }
 
-    this.reportStateToShiny('start')
+    this.emitStateEvent('start')
 
     this.element.classList.remove('finished')
     this.element.classList.add('running')
@@ -269,7 +269,7 @@ class CountdownTimer {
     }
   }
 
-  stop () {
+  stop ({manual = false} = {}) {
     const { remaining } = this.remainingTime()
     if (remaining > 1) {
       this.remaining = remaining
@@ -280,17 +280,19 @@ class CountdownTimer {
     this.element.classList.add('finished')
     this.is_running = false
     this.end = null
-    this.reportStateToShiny('stop')
+    this.emitStateEvent(manual ? 'stop' : 'finished')
     this.timeout = clearTimeout(this.timeout)
   }
 
   reset () {
-    this.stop()
+    this.stop({manual: true})
     this.remaining = null
     this.update(true)
-    this.reportStateToShiny('reset')
+
     this.element.classList.remove('finished')
     this.element.classList.remove('warning')
+    this.emitEvents = true
+    this.emitStateEvent('reset')
   }
 
   setValues (opts) {
@@ -316,7 +318,7 @@ class CountdownTimer {
         this.start()
       }
     }
-    this.reportStateToShiny('update')
+    this.emitStateEvent('update')
     this.update(true)
   }
 
@@ -333,7 +335,7 @@ class CountdownTimer {
       newRemaining = Math.round(newRemaining / 5) * 5
     }
     this.setRemaining(newRemaining)
-    this.reportStateToShiny(val > 0 ? 'bumpUp' : 'bumpDown')
+    this.emitStateEvent(val > 0 ? 'bumpUp' : 'bumpDown')
     this.update(true)
   }
 
@@ -394,15 +396,10 @@ class CountdownTimer {
     }
   }
 
-  reportStateToShiny (action) {
-    if (!window.Shiny) return
-
-    const inputId = this.element.id
+  emitStateEvent (action) {
     const data = {
-      event: {
-        action,
-        time: new Date().toISOString()
-      },
+      action,
+      time: new Date().toISOString(),
       timer: {
         is_running: this.is_running,
         end: this.end ? new Date(this.end).toISOString() : null,
@@ -410,15 +407,24 @@ class CountdownTimer {
       }
     }
 
-    function shinySetInputValue () {
-      if (!window.Shiny.setInputValue) {
-        setTimeout(shinySetInputValue, 100)
-        return
-      }
-      window.Shiny.setInputValue(inputId, data)
+    this.reportStateToShiny(data)
+    this.element.dispatchEvent(new CustomEvent('countdown', { detail: data, bubbles: true }))
+  }
+
+  reportStateToShiny (data) {
+    if (!window.Shiny) return
+
+    if (!window.Shiny.setInputValue) {
+      // We're in Shiny but it isn't ready for input updates yet
+      setTimeout(() => this.reportStateToShiny(data), 100)
+      return
     }
 
-    shinySetInputValue()
+    const { action, time, timer } = data
+
+    const shinyData = { event: { action, time }, timer }
+
+    window.Shiny.setInputValue(this.element.id, shinyData)
   }
 }
 
@@ -453,7 +459,7 @@ class CountdownTimer {
       Shiny.addCustomMessageHandler('countdown:stop', function (id) {
         const el = document.getElementById(id)
         if (!el) return
-        el.countdown.stop()
+        el.countdown.stop({manual: true})
       })
 
       Shiny.addCustomMessageHandler('countdown:reset', function (id) {

--- a/inst/countdown/countdown.js
+++ b/inst/countdown/countdown.js
@@ -262,7 +262,11 @@ class CountdownTimer {
       Math.round(remaining) % this.update_every === 0
 
     if (should_update) {
-      this.element.classList.toggle('warning', remaining <= this.warn_when)
+      const is_warning = remaining <= this.warn_when
+      if (is_warning && !this.element.classList.contains('warning')) {
+        this.emitStateEvent('warning')
+      }
+      this.element.classList.toggle('warning', is_warning)
       this.display = { minutes, seconds }
       setRemainingTime('.minutes', minutes)
       setRemainingTime('.seconds', seconds)

--- a/inst/examples/shiny-app/ui.R
+++ b/inst/examples/shiny-app/ui.R
@@ -1,7 +1,8 @@
 library(shiny)
+library(bslib)
 library(countdown)
 
-ui <- fluidPage(
+ui <- page_fixed(
   title = "{countdown} - Example Shiny App",
   div(
     class = "container",

--- a/man/countdown-package.Rd
+++ b/man/countdown-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{countdown-package}
 \alias{countdown-package}
-\alias{_PACKAGE}
 \title{countdown: A Countdown Timer for HTML Presentations, Documents, and Web Apps}
 \description{
 A simple countdown timer for slides and HTML documents written in 'R Markdown' or 'Quarto'. Integrates fully into 'Shiny' apps. Countdown to something amazing.


### PR DESCRIPTION
Fixes #31

Now we emit native browser events in addition to sending timer state change events to Shiny.

I also added two new events:

* When the timer runs its course (or is bumped down to the end of the timer) we emit a `"finished"` event.
* When the timer hits the warning period, it emits a "warning" event.

## TODO

- [x] Rebase after merging #36
- [x] Add news item
- [x] rebuild docs