### PR TITLE
fix: Use custom URL for sound

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,11 +15,17 @@
 
 * Implemented emitting of native browser events alongside Shiny communication. (#37)
 
-* Added two new event types: `"finished"` when the timer completes its cycle and `"warning"` when it reaches the warning period. (#37)
-  
+* Added two new event types: `"finished"` when the timer completes its cycle
+  and `"warning"` when it reaches the warning period. (#37)
+
 * Set `class = "inline"` in `countdown()` to create an inline, rather than
   absolute-positioned, countdown timer. (#36)
-  
+
+## Bug fixes
+
+* Fixed an issue where custom URLs for `play_sound` were not used for the timer
+  end sound. (thanks @jannismain, #38)
+
 ## Changes
 
 * Switched to using `{bslib}` to stylize the demo countdown shiny app. (#37)

--- a/inst/countdown/countdown.js
+++ b/inst/countdown/countdown.js
@@ -14,6 +14,7 @@ class CountdownTimer {
     const duration = minutes * 60 + seconds
 
     function attrIsTrue (x) {
+      if (typeof x === 'undefined') return false
       if (x === true) return true
       return !!(x === 'true' || x === '' || x === '1')
     }
@@ -24,7 +25,7 @@ class CountdownTimer {
     this.is_running = false
     this.warn_when = parseInt(el.dataset.warnWhen) || -1
     this.update_every = parseInt(el.dataset.updateEvery) || 1
-    this.play_sound = attrIsTrue(el.dataset.playSound)
+    this.play_sound = attrIsTrue(el.dataset.playSound) || el.dataset.playSound
     this.blink_colon = attrIsTrue(el.dataset.blinkColon)
     this.startImmediately = attrIsTrue(el.dataset.startImmediately)
     this.timeout = null


### PR DESCRIPTION
Fixes the use of custom URLs when `play_sound="...url..."`.

Fixes #38