### PR TITLE
feat(css): Add `no-controls` class

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@
 * Set `class = "inline"` in `countdown()` to create an inline, rather than
   absolute-positioned, countdown timer. (#36)
 
+* Set `class = "no-controls"` in `countdown()` to create a countdown timer
+  without the controls. (#40)
+
 ## Bug fixes
 
 * Fixed an issue where custom URLs for `play_sound` were not used for the timer

--- a/R/countdown.R
+++ b/R/countdown.R
@@ -55,6 +55,12 @@
 #'   containing the timer. The `"countdown"` class is added automatically. If
 #'   you want to modify the style of the timer, you can modify the `"countdown"`
 #'   class or specify additional styles here that extend the base CSS.
+#'
+#'   `countdown()` provides two built-in classes:
+#'
+#'    * Use `"inline"` to create an inline, rather than absolutely-positioned,
+#'      timer. This is useful for timers in prose or documents.
+#'    * Use `"no-controls"` for a timer without the up/down controls.
 #' @param style CSS rules to be applied inline to the timer. Use `style` to
 #'   override any global CSS rules for the timer. For example, to display the
 #'   timer relative to the position where it is called (rather than positioned

--- a/inst/countdown/countdown.css
+++ b/inst/countdown/countdown.css
@@ -78,7 +78,8 @@
 }
 
 /* ------ Controls ------ */
-.countdown:not(.running) .countdown-controls {
+.countdown:not(.running) .countdown-controls,
+.countdown.no-controls .countdown-controls {
   display: none;
 }
 

--- a/man/countdown.Rd
+++ b/man/countdown.Rd
@@ -101,7 +101,14 @@ specific reason, it would probably be best to leave this unset.}
 \item{class}{Optional additional classes to be added to the \verb{<div>}
 containing the timer. The \code{"countdown"} class is added automatically. If
 you want to modify the style of the timer, you can modify the \code{"countdown"}
-class or specify additional styles here that extend the base CSS.}
+class or specify additional styles here that extend the base CSS.
+
+\code{countdown()} provides two built-in classes:
+\itemize{
+\item Use \code{"inline"} to create an inline, rather than absolutely-positioned,
+timer. This is useful for timers in prose or documents.
+\item Use \code{"no-controls"} for a timer without the up/down controls.
+}}
 
 \item{style}{CSS rules to be applied inline to the timer. Use \code{style} to
 override any global CSS rules for the timer. For example, to display the


### PR DESCRIPTION
`countdown(class = "no-controls")` now hides the up/down controls in case you don't want to let the user change the timer while running.