### PR TITLE
Disable r-cmd-check from running if changes are not detected inside of the `r/` folder

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,10 +1,16 @@
 # Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
-on:
+
+# Restrict the job to run only if files inside the `r/*` directory change
+on: 
   push:
     branches: [main, master]
+    paths:
+      - r/**
   pull_request:
     branches: [main, master]
+    paths:
+      - r/**
   workflow_dispatch: {}
 
 name: R-CMD-check


### PR DESCRIPTION
Minor convenience change and avoiding spending unnecessary electrons/time on running R checks when nothing changes in the R directory. 